### PR TITLE
changed lateralisation to fix divide by zero error to fix issue #38

### DIFF
--- a/mega_analysis/crosstab/mega_analysis/QUERY_LATERALISATION.py
+++ b/mega_analysis/crosstab/mega_analysis/QUERY_LATERALISATION.py
@@ -21,7 +21,8 @@ def gifs_lat(gif_lat_file):
 
 def QUERY_LATERALISATION(inspect_result, df, map_df_dict, gif_lat_file,
                        side_of_symptoms_signs=None,
-                       pts_dominant_hemisphere_R_or_L=None):
+                       pts_dominant_hemisphere_R_or_L=None,
+                       normalise_lat_to_loc=False):
     """
     After obtaining inspect_result and clinician's filter, can optionally use this function to determine
     lateralisation e.g. for EpiNav(R) visualisation.
@@ -200,14 +201,14 @@ def QUERY_LATERALISATION(inspect_result, df, map_df_dict, gif_lat_file,
         higher_value = higher_value.remove(lower_value)
 
         ratio = lower_value / Total
-        norm_ratio = ratio / proportion_lateralising  # see comments on section above about why we should normalise
-        #  # alternatively:
-        # norm_ratio = ratio * (2-proportion_lateralising)
-        # limit it to zero and 1:
-        if norm_ratio > 1:
-            norm_ratio = 1
-            print('norm_ratio capped at 1: small proportion of data lateralised')
 
+        if normalise_lat_to_loc==True:
+            norm_ratio = ratio / proportion_lateralising  # see comments on section above about why we should normalise
+            if norm_ratio > 1:
+                norm_ratio = 1
+                print('norm_ratio capped at 1: small proportion of data lateralised')
+        elif normalise_lat_toloc==False:
+            norm_ratio = lower_value / higher_value
 
 
         # if proportion_lateralising is 1, straightforward: return dataframe of right/left gifs whichever lower

--- a/mega_analysis/crosstab/mega_analysis/QUERY_LATERALISATION.py
+++ b/mega_analysis/crosstab/mega_analysis/QUERY_LATERALISATION.py
@@ -207,7 +207,7 @@ def QUERY_LATERALISATION(inspect_result, df, map_df_dict, gif_lat_file,
             if norm_ratio > 1:
                 norm_ratio = 1
                 print('norm_ratio capped at 1: small proportion of data lateralised')
-        elif normalise_lat_toloc==False:
+        elif normalise_lat_to_loc==False:
             norm_ratio = lower_value / higher_value
 
 

--- a/mega_analysis/crosstab/mega_analysis/QUERY_LATERALISATION.py
+++ b/mega_analysis/crosstab/mega_analysis/QUERY_LATERALISATION.py
@@ -198,7 +198,7 @@ def QUERY_LATERALISATION(inspect_result, df, map_df_dict, gif_lat_file,
 
         lower_value = [Right, Left][lower_postn]
         higher_value = [Right, Left]
-        higher_value = higher_value.remove(lower_value)
+        higher_value.remove(lower_value)
 
         ratio = lower_value / Total
 


### PR DESCRIPTION
I've changed the default behaviour of QUERY_LATERALISATION to look at the absolute ratio of left vs right, and reduce the lower gif_parcellations proportionally. 

if this solves the issue #38, then it is good but I expect this change to SIGNIFICANTLY effect visualisation.

Therefore, in the advanced option of the GUI (#19), would be useful to have a lateralisaiton setting which by default the checkbox is unticked:

```
- [] lat to loc proportion = False
```

the above checkbox should refer to the below keyword argument, and be set to true when ticked:
```
QUERY_LATERALISATION(...,
                                        normalise_lat_to_loc=False)

```

This way, I can review how significantly it effects all the set semiology_terms and others. 