### PR TITLE
Add tests to check neutral laterality

### DIFF
--- a/mega_analysis/crosstab/mega_analysis/exclusions.py
+++ b/mega_analysis/crosstab/mega_analysis/exclusions.py
@@ -113,6 +113,7 @@ def exclude_cortical_stimulation(df):
     """
     df.loc[df[sEEG_ES]=='ES', sEEG_ES] = np.nan
     df_exclusions_CES = df.dropna(subset=[post_op, concordant, sEEG_ES], thresh=1, axis=0, inplace=False)
+    return df_exclusions_CES
     # # second part for test later
     # CES = 'Cortical Stimulation (CS)'
     # df_exclusions_CES = df_exclusions_CES.loc[~df[CES].notnull(), :]

--- a/mega_analysis/crosstab/mega_analysis/exclusions.py
+++ b/mega_analysis/crosstab/mega_analysis/exclusions.py
@@ -123,7 +123,7 @@ def exclude_sEEG(df):
     """
     exclude cases where the only ground truth is stereo EEG cases.
     I recommend also excluding exclude_cortical_stimulation if running this.
-    """"
+    """
     df.loc[df[sEEG_ES]=='y', sEEG_ES] = np.nan
     df_exclusions_sEEG = df.dropna(subset=[post_op, concordant, sEEG_ES], thresh=1, axis=0, inplace=False)
     return df_exclusions_sEEG

--- a/mega_analysis/semiology.py
+++ b/mega_analysis/semiology.py
@@ -12,7 +12,9 @@ from mega_analysis.crosstab.mega_analysis.QUERY_LATERALISATION import QUERY_LATE
 from mega_analysis.crosstab.mega_analysis.exclusions import (
     exclusions,
     exclude_ET,
-    exclude_sEEG_ES,
+    exclude_sEEG,
+    exclude_cortical_stimulation,
+    exclude_seizure_free,
 )
 
 
@@ -68,7 +70,8 @@ class Semiology:
             dominant_hemisphere: Laterality,
             include_seizure_freedom: bool = True,
             include_concordance: bool = True,
-            include_seeg_es: bool = True,
+            include_seeg: bool = True,
+            include_cortical_stimulation: bool = True,
             include_et_topology_ez: bool = True,
             ):
         self.term = term
@@ -78,7 +81,8 @@ class Semiology:
             mega_analysis_df,
             include_seizure_freedom,
             include_concordance,
-            include_seeg_es,
+            include_seeg,
+            include_cortical_stimulation,
             include_et_topology_ez,
         )
 
@@ -87,17 +91,20 @@ class Semiology:
             df,
             include_seizure_freedom,
             include_concordance,
-            include_seeg_es,
+            include_seeg,
+            include_cortical_stimulation,
             include_et_topology_ez,
             ):
-        if not include_seizure_freedom:
-            pass  # TODO by Ali
         if not include_concordance:
             df = exclusions(df, CONCORDANCE=True)
+        if not include_seizure_freedom:
+            df = exclude_seizure_free(df)
         if not include_et_topology_ez:
             df = exclude_ET(df)
-        if not include_seeg_es:
-            df = exclude_sEEG_ES(df)
+        if not include_seeg:
+            df = exclude_sEEG(df)
+        if not include_cortical_stimulation:
+            df = exclude_cortical_stimulation(df)
         return df
 
     def query_semiology(self) -> pd.DataFrame:

--- a/tests/test_exclusions.py
+++ b/tests/test_exclusions.py
@@ -1,0 +1,24 @@
+import unittest
+from mega_analysis.semiology import mega_analysis_df
+from mega_analysis.crosstab.mega_analysis.exclusions import (
+    exclusions,
+    exclude_ET,
+    exclude_sEEG_ES,
+)
+
+
+class TestExclusions(unittest.TestCase):
+    def setUp(self):
+        self.df = mega_analysis_df.copy()
+
+    def test_default_no_exclusions(self):
+        assert self.df.equals(exclusions(self.df))
+
+    def test_exclusions(self):
+        assert not self.df.equals(exclusions(self.df, CONCORDANCE=True))
+
+    def test_exclude_et(self):
+        assert not self.df.equals(exclude_ET(self.df))
+
+    def test_exclude_seeg_es(self):
+        assert not self.df.equals(exclude_sEEG_ES(self.df))

--- a/tests/test_exclusions.py
+++ b/tests/test_exclusions.py
@@ -3,7 +3,9 @@ from mega_analysis.semiology import mega_analysis_df
 from mega_analysis.crosstab.mega_analysis.exclusions import (
     exclusions,
     exclude_ET,
-    exclude_sEEG_ES,
+    exclude_sEEG,
+    exclude_cortical_stimulation,
+    exclude_seizure_free,
 )
 
 
@@ -21,4 +23,4 @@ class TestExclusions(unittest.TestCase):
         assert not self.df.equals(exclude_ET(self.df))
 
     def test_exclude_seeg_es(self):
-        assert not self.df.equals(exclude_sEEG_ES(self.df))
+        assert not self.df.equals(exclude_sEEG(self.df))

--- a/tests/test_semiology.py
+++ b/tests/test_semiology.py
@@ -1,16 +1,73 @@
 import unittest
 from mega_analysis.semiology import Semiology, Laterality
 
+
 class TestSemiology(unittest.TestCase):
     def test_existing_aphasia(self):
         semiology = Semiology('Aphasia', Laterality.LEFT, Laterality.LEFT)
         num_patients_dict = semiology.get_num_patients_dict()
         self.assertIs(type(num_patients_dict), dict)
 
+    def test_neutral_symptoms_side_aphasia(self):
+        semiology = Semiology('Aphasia', Laterality.NEUTRAL, Laterality.LEFT)
+        num_patients_dict = semiology.get_num_patients_dict()
+        self.assertIs(type(num_patients_dict), dict)
+
+    def test_neutral_dominant_hemisphere_aphasia(self):
+        semiology = Semiology('Aphasia', Laterality.LEFT, Laterality.NEUTRAL)
+        num_patients_dict = semiology.get_num_patients_dict()
+        self.assertIs(type(num_patients_dict), dict)
+
+    def test_neutral_all_aphasia(self):
+        semiology = Semiology(
+            'Aphasia', Laterality.NEUTRAL, Laterality.NEUTRAL)
+        num_patients_dict = semiology.get_num_patients_dict()
+        self.assertIs(type(num_patients_dict), dict)
+
+
     def test_existing_aphemia(self):
         semiology = Semiology('Aphemia', Laterality.LEFT, Laterality.LEFT)
         num_patients_dict = semiology.get_num_patients_dict()
         self.assertIs(type(num_patients_dict), dict)
+
+    def test_neutral_symptoms_side_aphemia(self):
+        semiology = Semiology('Aphemia', Laterality.NEUTRAL, Laterality.LEFT)
+        num_patients_dict = semiology.get_num_patients_dict()
+        self.assertIs(type(num_patients_dict), dict)
+
+    def test_neutral_dominant_hemisphere_aphemia(self):
+        semiology = Semiology('Aphemia', Laterality.LEFT, Laterality.NEUTRAL)
+        num_patients_dict = semiology.get_num_patients_dict()
+        self.assertIs(type(num_patients_dict), dict)
+
+    def test_neutral_all_aphemia(self):
+        semiology = Semiology(
+            'Aphemia', Laterality.NEUTRAL, Laterality.NEUTRAL)
+        num_patients_dict = semiology.get_num_patients_dict()
+        self.assertIs(type(num_patients_dict), dict)
+
+
+    def test_existing_blink(self):
+        semiology = Semiology('Blink', Laterality.LEFT, Laterality.LEFT)
+        num_patients_dict = semiology.get_num_patients_dict()
+        self.assertIs(type(num_patients_dict), dict)
+
+    def test_neutral_symptoms_side_blink(self):
+        semiology = Semiology('Blink', Laterality.NEUTRAL, Laterality.LEFT)
+        num_patients_dict = semiology.get_num_patients_dict()
+        self.assertIs(type(num_patients_dict), dict)
+
+    def test_neutral_dominant_hemisphere_blink(self):
+        semiology = Semiology('Blink', Laterality.LEFT, Laterality.NEUTRAL)
+        num_patients_dict = semiology.get_num_patients_dict()
+        self.assertIs(type(num_patients_dict), dict)
+
+    def test_neutral_all_blink(self):
+        semiology = Semiology(
+            'Blink', Laterality.NEUTRAL, Laterality.NEUTRAL)
+        num_patients_dict = semiology.get_num_patients_dict()
+        self.assertIs(type(num_patients_dict), dict)
+
 
     def test_non_existing(self):
         semiology = Semiology('No semiology', Laterality.LEFT, Laterality.LEFT)


### PR DESCRIPTION
The tests for this are currently failing:

```
============================================================================= short test summary info =============================================================================
FAILED tests/test_semiology.py::TestSemiology::test_neutral_all_aphasia - AssertionError: <class 'NoneType'> is not <class 'dict'>
FAILED tests/test_semiology.py::TestSemiology::test_neutral_all_aphemia - AssertionError: <class 'NoneType'> is not <class 'dict'>
FAILED tests/test_semiology.py::TestSemiology::test_neutral_all_blink - AssertionError: <class 'NoneType'> is not <class 'dict'>
FAILED tests/test_semiology.py::TestSemiology::test_neutral_dominant_hemisphere_aphasia - UnboundLocalError: local variable 'all_combined_gifs' referenced before assignment
FAILED tests/test_semiology.py::TestSemiology::test_neutral_dominant_hemisphere_aphemia - UnboundLocalError: local variable 'all_combined_gifs' referenced before assignment
FAILED tests/test_semiology.py::TestSemiology::test_neutral_symptoms_side_aphasia - AssertionError: <class 'NoneType'> is not <class 'dict'>
FAILED tests/test_semiology.py::TestSemiology::test_neutral_symptoms_side_aphemia - AssertionError: <class 'NoneType'> is not <class 'dict'>
FAILED tests/test_semiology.py::TestSemiology::test_neutral_symptoms_side_blink - AssertionError: <class 'NoneType'> is not <class 'dict'>
==================================================================== 8 failed, 9 passed, 12 warnings in 9.20s =====================================================================
```

In the tests where it says `<class 'NoneType'> is not <class 'dict'>`, `QUERY_LATERALISATION()` returned `None`. This happens always when the symptoms side is not specified, for the three tested semiology terms.

The others are caused by a bug in `QUERY_LATERALISATION()`. If the dominant hemisphere is not specified, the `UnboundError` is raised. I think the problems start because this DF is empty:
https://github.com/thenineteen/Semiology-Visualisation-Tool/blob/3d3a3fdaaafe76ef6b1d44bcc9fd90ee6f4138fc/mega_analysis/crosstab/mega_analysis/QUERY_LATERALISATION.py#L103