### PR TITLE
Lateralisation corrections and check neutral laterality

### DIFF
--- a/mega_analysis/crosstab/mega_analysis/QUERY_LATERALISATION.py
+++ b/mega_analysis/crosstab/mega_analysis/QUERY_LATERALISATION.py
@@ -107,7 +107,26 @@ def QUERY_LATERALISATION(inspect_result, df, map_df_dict, gif_lat_file,
     if not side_of_symptoms_signs and not pts_dominant_hemisphere_R_or_L:
         print('Please note you must determine at least one of side_of_symptoms_signs')
         print('or pts_dominant_hemisphere_R_or_L keyword arguments for lateralised data extraction')
-        
+        inspect_result
+        # now clean ready to map:
+        inspect_result.drop(labels=id_cols, axis='columns', inplace=True, errors='ignore')
+        inspect_result.dropna(how='all', axis='columns', inplace=True)
+        # now map:
+        gifs_all = pivot_result_to_one_map(inspect_result, 
+                                            one_map, raw_pt_numbers_string='pt #s',
+                                            suppress_prints=True)
+        # if EpiNav doesn't sum the pixel intensities: (infact even if it does)
+        fixed = gifs_all.pivot_table(columns='Gif Parcellations', values='pt #s', aggfunc='sum')
+        fixed2 = fixed.melt(value_name='pt #s')
+        fixed2.insert(0, 'Semiology Term', np.nan)
+        # fixed2.loc[0, 'Semiology Term'] = str( list(inspect_result.index.values) )
+        gifs_all = fixed2
+
+        return gifs_all.round()
+
+
+
+
 
     # cycle through rows of inspect_result_lat:
     id_cols = [i for i in full_id_vars() if i not in ['Localising']]  # note 'Localising' is in id_cols
@@ -229,6 +248,9 @@ def QUERY_LATERALISATION(inspect_result, df, map_df_dict, gif_lat_file,
         elif i != 0:
             all_combined_gifs = pd.concat([all_combined_gifs, row_to_one_map], join='outer', sort=False)
         logging.debug(f'end of i {i}')
+
+
+
 
 
 

--- a/mega_analysis/crosstab/mega_analysis/group_columns.py
+++ b/mega_analysis/crosstab/mega_analysis/group_columns.py
@@ -6,12 +6,13 @@ import pandas as pd
 
 def full_id_vars():
     id_cols = ['Reference', 'Relevant Tot Sample', 'Tot Pt included',
-                    'Reported Semiology', 'Semiology Category', 'Ground truth description',
-                    'Post-op Sz Freedom (Engel Ia, Ib; ILAE 1, 2)',
+                'Reported Semiology', 'Semiology Category', 'Ground truth description',
+                'Post-op Sz Freedom (Engel Ia, Ib; ILAE 1, 2)',
                 'Concordant Neurophys & Imaging (MRI, PET, SPECT)',
                 'sEEG and/or ES',
                 'Localising', 'Reported Localisation',
-                    '# tot pt in the paper', '# pt excluded', '# pt sz free post-surg',
+                'padeiatric? <7 years (0-6 yrs) y/n',
+                '# tot pt in the paper', '# pt excluded', '# pt sz free post-surg',
                 'Spontaneous Semiology (SS)', 'Epilepsy Topology (ET)', 'Cortical Stimulation (CS)', 'Other (e.g. Abs)']
     
     return id_cols
@@ -24,6 +25,6 @@ def lateralisation_vars():
 
 
 def anatomical_regions(df):
-    localisation_labels = df.columns[17:72]  # for July 2019 version at least
+    localisation_labels = df.columns[17:102]  # March 2020 17:102. Prev 17:72. 
 
     return localisation_labels


### PR DESCRIPTION
QUERY_LATERALISATION changes:

1. fixed a bug which excluded localising data when non lateralising data was available at the patient-level

2. should now be able to run even when not specifying symptom (side_of_symptoms_signs) side nor dominant hemisphere (pts_dominant_hemisphere_R_or_L)