### PR TITLE
combine lateralising and non-lateralising localisation using pd.concat.

### DIFF
--- a/mega_analysis/crosstab/mega_analysis/QUERY_LATERALISATION.py
+++ b/mega_analysis/crosstab/mega_analysis/QUERY_LATERALISATION.py
@@ -230,6 +230,21 @@ def QUERY_LATERALISATION(inspect_result, df, map_df_dict, gif_lat_file,
             all_combined_gifs = pd.concat([all_combined_gifs, row_to_one_map], join='outer', sort=False)
         logging.debug(f'end of i {i}')
 
+    
+    # Need to recombine the inspect_result_lat used in for loop to give all_combined_gifs
+    # with inspect_result that had null lateralising:
+    inspect_result_nulllateralising = inspect_result.loc[inspect_result['Lateralising'].isnull(), :]
+    # now clean ready to map:
+    inspect_result_nulllateralising.drop(labels=id_cols, axis='columns', inplace=True, errors='ignore')
+    inspect_result_nulllateralising.dropna(how='all', axis='columns', inplace=True)
+    # now map:
+    gifs_not_lat = pivot_result_to_one_map(inspect_result_nulllateralising, 
+                                           one_map, raw_pt_numbers_string='pt #s',
+                                           suppress_prints=True)
+    #now combine:
+    all_combined_gifs = pd.concat([all_combined_gifs, gifs_not_lat], join='outer', sort=False) 
+
+
 
     # if EpiNav doesn't sum the pixel intensities: (infact even if it does)
     fixed = all_combined_gifs.pivot_table(columns='Gif Parcellations', values='pt #s', aggfunc='sum')


### PR DESCRIPTION
 To fix aphasia searches with dominant laterality,

attempt to fix #63 

seems to break one extra test (blink) and does change the structure/score printout and visualisation, but the log messages still state:

```
Localising Datapoints relevant to query (?i)Aphasia: 3.0
Lateralising Datapoints relevant to query: 2.0
Lateralisation based on: 2.0 datapoints

No missing Lateralising data points.
Overall Contralateral: 0 datapoints
Ipsilateral: 0 datapoints
Bilateral/Non-lateralising: 0 datapoints. This is not utilised in our analysis/visualisation.
Dominant Hemisphere: 2.0 datapoints
Non-Dominant Hemisphere: 0 datapoints
```