### PR TITLE
semiology dictionary categories updated

### DIFF
--- a/resources/semiology_dictionary.yaml
+++ b/resources/semiology_dictionary.yaml
@@ -143,7 +143,7 @@
         "hears? (?:vague)? sounds?",
         "hears? echoe?s?",
         "hears? noises?",
-        "whistle", 
+        "whistle",
         "whistling",
       ]
     "Visual":
@@ -249,10 +249,10 @@
           "fig of 4",
           "figure 4",
         ]
-      "Dystonic": 
+      "Dystonic":
         [
-          "(?<!no )dystonic", 
-          "twisted postur", 
+          "(?<!no )dystonic",
+          "twisted postur",
           "twisting", #"supinat"
         ]
       "Clonic":
@@ -300,15 +300,20 @@
           "head rock",
           "rocks from side",
         ]
-      "Hypomotor":
+      "Behavioural Arrest":
         [
-          "unilateral ictal paresis",
-          "(?:relative)? ictal immobility",
           "behaviour(?:al)? arrest",
           "akinetic attack",
-          "hypomotor",
+          "(?:relative)? ictal immobility",
+          "freeze", "unable to move",
         ]
+      "Other Complex Motor": ["complex motor", "complicated motor"]
+    special seizures:
       "Atonic": ["atonic", "flaccid", "loss of tone", "jelly"]
+      "Ictal Limb Paresis":
+        [
+          "unilateral ictal paresis",
+        ]
       "Astatic":
         [
           "astatic",
@@ -317,7 +322,7 @@
           "falls? to ground",
           "drop attack",
         ]
-      "Other Complex Motor": ["complex motor", "complicated motor"]
+      "Hypomotor": ["hypomotor"]
     automatisms:
       "Oral Automatisms":
         [
@@ -373,28 +378,28 @@
       "Cough": ["ictal cough", "cough seizure"]
       "Nose-wiping":
         [
-          "(?<!no )nose-? ?wip", 
-          "rubs? nose", 
-          "nose rub", 
+          "(?<!no )nose-? ?wip",
+          "rubs? nose",
+          "nose rub",
           "wipes? nose"
         ]
-      "Spitting": 
+      "Spitting":
         [
-          " spit", 
+          " spit",
           "spitting",
         ]
       "Drinking":
         [
-          "ictal drink", 
-          " sip(ping)? ", 
+          "ictal drink",
+          " sip(ping)? ",
           "ictal swallow",
         ]
       "Gelastic":
         [
-          "laughter", 
-          "(?<!no )laughing", 
-          "laugh", 
-          "(?<!no )gelastic", 
+          "laughter",
+          "(?<!no )laughing",
+          "laugh",
+          "(?<!no )gelastic",
           "giggl"]
       "Dacrystic":
         [
@@ -446,7 +451,7 @@
       [
         "(?<!no) dysphasia",
         "(?<!no) difficulty speak(?:ing)?",
-        "(?<!no) difficulty talk(?:ing)?",        
+        "(?<!no) difficulty talk(?:ing)?",
         "speech difficult",
         "difficult speech",
         "(?<!no) distortion of speech",


### PR DESCRIPTION
changed hypomotor to behavioural arrest as hypomotor is for paediatric cases only.

reclassified a few seizures under a new subcategory of special seziures which are well recognised in the literature.

ictal limb paresis added as a new semiology (separated from previous incorrect hypomotor)

(added hypomotor to its own category - need to be careful with this one as it captures what we have labelled as a category of hypomotor which hasn't been updated in the excel file - note to @thenineteen and @neurokleos  to remember to review all hypomotor labels in the excel file )